### PR TITLE
(fix): operator definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codegen-cpp README
 
-I grew tired of "writing" C++ definition stubs by copying around declarations from (interface) header files. Thus I wrote this extension, which helps generating said stubs from a header file. Additionally it allows creating the necessary files for an implementation of a given interface. 
+I grew tired of "writing" C++ definition stubs by copying around declarations from (interface) header files. Thus I wrote this extension, which helps generating said stubs from a header file. Additionally it allows creating the necessary files for an implementation of a given interface.  Multiline declarations and nested classes/namespaces are supported.
 Still not perfect, but should work for the most common use cases.
 ## Features
 The extension is automatically loaded when using the C++ language. 
@@ -29,12 +29,17 @@ The following settings are available:
 ## Issues
 Can be reported [here](https://github.com/HerrFroehlich/vscode_cpp_codegen/issues). Contributions are also welcome in any form.
 ### Known
+#### Major
 * Updating existing header files is not supported
 * `using` statements are not evaluated
 * `struct`s are not supported
 * Newly created folders are not detected for selection until reloading VS-Code window
-* cast operator not serialized properly
 * friend declarations parsed wrongly
+* preprocessor macros after `class` specifier are not working
+
+
+#### Minor, internal
+* enum classes are deserialized as classes 
 
 ## Possible features in future
 * Generating code only for selected text ranges

--- a/src/cpp/MemberFunction.ts
+++ b/src/cpp/MemberFunction.ts
@@ -19,7 +19,7 @@ export class MemberFunction extends io.TextScope implements IFunction {
     switch (options.mode) {
       case io.SerializableMode.source:
         serial = this.getHeading(options) + " {\n";
-        if (this.returnVal !== "void") {
+        if (this.returnVal.length && this.returnVal !== "void") {
           serial +=
             "\t" + this.returnVal + " returnValue;\n\treturn returnValue;\n";
         }

--- a/src/test/suite/full.memberfunctions.test.ts
+++ b/src/test/suite/full.memberfunctions.test.ts
@@ -1,9 +1,5 @@
 import * as assert from "assert";
-import { Done, describe, it, test } from "mocha";
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-import * as vscode from "vscode";
+import { describe, test } from "mocha";
 import { callItAsync } from "./utils";
 
 import { HeaderParser } from "../../io/HeaderParser";

--- a/src/test/suite/operator.test.ts
+++ b/src/test/suite/operator.test.ts
@@ -1,0 +1,280 @@
+import * as assert from "assert";
+import { describe, test } from "mocha";
+import { callItAsync } from "./utils";
+
+import { HeaderParser } from "../../io/HeaderParser";
+import {
+  MemberFunction,
+  PureVirtualMemberFunction,
+  VirtualMemberFunction,
+} from "../../cpp";
+import { TextFragment, SerializableMode } from "../../io";
+
+class OperatorData {
+  constructor(
+    public type: string,
+    public args: string,
+    public returnVal: string
+  ) {}
+  public toString(): string {
+    return this.returnVal + " " + this.funcName() + " (" + this.args + ")";
+  }
+
+  public funcName(): string {
+    return "operator" + this.type;
+  }
+}
+class VirtualOperatorData extends OperatorData {
+  constructor(private innerData: OperatorData) {
+    super(innerData.type, innerData.args, innerData.returnVal);
+  }
+  public toString(): string {
+    return "virtual " + this.innerData.toString();
+  }
+}
+class OverrideOperatorData extends OperatorData {
+  constructor(private innerData: OperatorData) {
+    super(innerData.type, innerData.args, innerData.returnVal);
+  }
+  public toString(): string {
+    return this.innerData.toString() + " override";
+  }
+}
+class PureVirtualOperatorData extends OperatorData {
+  constructor(private innerData: OperatorData) {
+    super(innerData.type, innerData.args, innerData.returnVal);
+  }
+  public toString(): string {
+    return this.innerData.toString() + " =0";
+  }
+}
+
+class ConstOperatorData extends OperatorData {
+  constructor(private innerData: OperatorData) {
+    super(innerData.type, innerData.args, innerData.returnVal);
+  }
+  public toString(): string {
+    return this.innerData.toString() + " const";
+  }
+}
+
+const overloadedOperatorData: OperatorData[] = [
+  new OperatorData("++", "", "int"),
+  new OperatorData("->", "", "int"),
+  new OperatorData("=", "const Type& other", "Type&"),
+  new OperatorData("()", "double x", "double"),
+  new OperatorData("[]", "int x", "double"),
+];
+const allocatorOperatorData: OperatorData[] = [
+  new OperatorData(" new", "std::size_t count", "void*"),
+  new OperatorData(" new[]", "std::size_t count", "void*"),
+  new OperatorData(" delete", "void* ptr", "void"),
+  new OperatorData(" delete[]", "void* ptr", "void"),
+];
+const castingOperatorData: OperatorData[] = [
+  new OperatorData(" int", "", ""),
+  new OperatorData(" long double*", "", ""),
+];
+
+const operatorData: OperatorData[] = overloadedOperatorData.concat(
+  allocatorOperatorData,
+  castingOperatorData
+);
+const virtualOperatorData: OperatorData[] = overloadedOperatorData
+  .concat(castingOperatorData)
+  .map((data) => new VirtualOperatorData(data));
+const virtualOperatorDataWithOverride = virtualOperatorData.concat(
+  overloadedOperatorData
+    .concat(castingOperatorData)
+    .map((data) => new OverrideOperatorData(data))
+);
+const pureVirtualOperatorData: OperatorData[] = virtualOperatorData.map(
+  (data) => new PureVirtualOperatorData(data)
+);
+const constOperatorData: OperatorData[] = overloadedOperatorData
+  .concat(castingOperatorData)
+  .map((data) => new ConstOperatorData(data));
+const constVirtualOperatorData: OperatorData[] = constOperatorData.map(
+  (data) => new VirtualOperatorData(data)
+);
+const constVirtualOperatorDataWithOverride = constVirtualOperatorData.concat(
+  constOperatorData.map((data) => new OverrideOperatorData(data))
+);
+const constPureVirtualOperatorData: OperatorData[] = constVirtualOperatorData.map(
+  (data) => new PureVirtualOperatorData(data)
+);
+
+suite("HeaderParser: Class Operator Declarations", () => {
+  describe("Operators are parsed correctly", () => {
+    callItAsync("With '${value}'", operatorData, async (data: OperatorData) => {
+      const testContent = TextFragment.createFromString(data.toString() + ";");
+
+      let parsedFunctions = HeaderParser.parseClassMemberFunctions(testContent);
+      assert.strictEqual(parsedFunctions.length, 1);
+      assert.strictEqual(parsedFunctions[0].name, data.funcName());
+      assert.strictEqual(parsedFunctions[0].returnVal, data.returnVal);
+      assert.strictEqual(parsedFunctions[0].args, data.args);
+    });
+  });
+
+  describe("Virtual operators are parsed correctly", () => {
+    callItAsync(
+      "With '${value}'",
+      virtualOperatorDataWithOverride,
+      async (data: OperatorData) => {
+        const testContent = TextFragment.createFromString(
+          data.toString() + ";"
+        );
+
+        let parsedFunctions = HeaderParser.parseClassMemberFunctions(
+          testContent
+        );
+        assert.strictEqual(parsedFunctions.length, 1);
+        assert.ok(parsedFunctions[0] instanceof VirtualMemberFunction);
+        assert.strictEqual(parsedFunctions[0].name, data.funcName());
+        assert.strictEqual(parsedFunctions[0].returnVal, data.returnVal);
+        assert.strictEqual(parsedFunctions[0].args, data.args);
+      }
+    );
+  });
+
+  describe("Pure virtual operators are parsed correctly", () => {
+    callItAsync(
+      "With '${value}'",
+      pureVirtualOperatorData,
+      async (data: OperatorData) => {
+        const testContent = TextFragment.createFromString(
+          data.toString() + ";"
+        );
+
+        let parsedFunctions = HeaderParser.parseClassMemberFunctions(
+          testContent
+        );
+        assert.strictEqual(parsedFunctions.length, 1);
+        assert.ok(parsedFunctions[0] instanceof PureVirtualMemberFunction);
+        assert.strictEqual(parsedFunctions[0].name, data.funcName());
+        assert.strictEqual(parsedFunctions[0].returnVal, data.returnVal);
+        assert.strictEqual(parsedFunctions[0].args, data.args);
+      }
+    );
+  });
+  describe("Const operators are parsed correctly", () => {
+    callItAsync(
+      "With '${value}'",
+      constOperatorData,
+      async (data: OperatorData) => {
+        const testContent = TextFragment.createFromString(
+          data.toString() + ";"
+        );
+
+        let parsedFunctions = HeaderParser.parseClassMemberFunctions(
+          testContent
+        );
+        assert.strictEqual(parsedFunctions.length, 1);
+        const memberFunction = parsedFunctions[0] as MemberFunction;
+        assert.strictEqual(memberFunction.name, data.funcName());
+        assert.strictEqual(memberFunction.returnVal, data.returnVal);
+        assert.strictEqual(memberFunction.args, data.args);
+        assert.ok(memberFunction.isConst);
+      }
+    );
+  });
+
+  describe("Const virtual operators are parsed correctly", () => {
+    callItAsync(
+      "With '${value}'",
+      constVirtualOperatorDataWithOverride,
+      async (data: OperatorData) => {
+        const testContent = TextFragment.createFromString(
+          data.toString() + ";"
+        );
+
+        let parsedFunctions = HeaderParser.parseClassMemberFunctions(
+          testContent
+        );
+        assert.strictEqual(parsedFunctions.length, 1);
+        assert.ok(parsedFunctions[0] instanceof VirtualMemberFunction);
+        const memberFunction = parsedFunctions[0] as VirtualMemberFunction;
+        assert.strictEqual(memberFunction.name, data.funcName());
+        assert.strictEqual(memberFunction.returnVal, data.returnVal);
+        assert.strictEqual(memberFunction.args, data.args);
+        assert.ok(memberFunction.isConst);
+      }
+    );
+  });
+
+  describe("Const pure virtual operators are parsed correctly", () => {
+    callItAsync(
+      "With '${value}'",
+      constPureVirtualOperatorData,
+      async (data: OperatorData) => {
+        const testContent = TextFragment.createFromString(
+          data.toString() + ";"
+        );
+
+        let parsedFunctions = HeaderParser.parseClassMemberFunctions(
+          testContent
+        );
+        assert.strictEqual(parsedFunctions.length, 1);
+        assert.ok(parsedFunctions[0] instanceof PureVirtualMemberFunction);
+        const memberFunction = parsedFunctions[0] as PureVirtualMemberFunction;
+        assert.strictEqual(memberFunction.name, data.funcName());
+        assert.strictEqual(memberFunction.returnVal, data.returnVal);
+        assert.strictEqual(memberFunction.args, data.args);
+        assert.ok(memberFunction.isConst);
+      }
+    );
+  });
+
+  describe("(De)allocator operators are serialized correctly for source file", () => {
+    callItAsync(
+      "With '${value}'",
+      allocatorOperatorData,
+      async (data: OperatorData) => {
+        const testContent = TextFragment.createFromString(
+          data.toString() + ";"
+        );
+
+        let parsedFunctions = HeaderParser.parseClassMemberFunctions(
+          testContent
+        );
+        assert.strictEqual(parsedFunctions.length, 1);
+        let expectedSerial =
+          data.returnVal +
+          " TestClass::" +
+          data.funcName() +
+          " (" +
+          data.args +
+          ") {\n";
+
+        expectedSerial =
+          expectedSerial +
+          (data.returnVal !== "void"
+            ? "\t" + data.returnVal + " returnValue;\n\treturn returnValue;\n}"
+            : "}");
+        const actualSerial = await parsedFunctions[0].serialize({
+          mode: SerializableMode.source,
+          nameScope: "TestClass",
+        });
+        assert.strictEqual(expectedSerial, actualSerial);
+      }
+    );
+  });
+
+  //TODO create a fuzzing test out of this?
+  test("Parsing multiple oeprators correctly", () => {
+    const testContent = TextFragment.createFromString(
+      `void* operator new(std::size_t s);
+       operator int();`
+    );
+
+    let parsedFunctions = HeaderParser.parseClassMemberFunctions(testContent);
+    assert.strictEqual(parsedFunctions.length, 2);
+    assert.strictEqual(parsedFunctions[0].name, "operator int");
+    assert.strictEqual(parsedFunctions[0].returnVal, "");
+    assert.strictEqual(parsedFunctions[0].args, "");
+    assert.strictEqual(parsedFunctions[1].name, "operator new");
+    assert.strictEqual(parsedFunctions[1].returnVal, "void*");
+    assert.strictEqual(parsedFunctions[1].args, "std::size_t s");
+  });
+});


### PR DESCRIPTION
Some operator definitions, like cast, Were not parsed properly yet. Fixed that by adding additional matchers in the header parser.